### PR TITLE
Change slugs to ascii only

### DIFF
--- a/dynamic_filenames.py
+++ b/dynamic_filenames.py
@@ -4,10 +4,14 @@ import re
 import uuid
 from string import Formatter
 
-try:  # use unicode-slugify library if installed
-    from slugify import slugify
-except ImportError:
-    from django.utils.text import slugify
+
+def slugify(value):
+    try:  # use unicode-slugify library if installed
+        from slugify import slugify as _slugify
+        return _slugify(value, only_ascii=True)
+    except ImportError:
+        from django.utils.text import slugify as _slugify
+        return _slugify(value, allow_unicode=False)
 
 
 class SlugFormatter(Formatter):

--- a/tests/test_dynamic_filenames.py
+++ b/tests/test_dynamic_filenames.py
@@ -100,8 +100,8 @@ class TestFilePattern:
 
     def test_call__slug(self):
         assert FilePattern(filename_pattern='{instance.title:slug}{ext}')(
-            instance=DefaultModel(title='best model'), filename='some_file.txt'
-        ) == 'best-model.txt'
+            instance=DefaultModel(title='best model with ünicode'), filename='some_file.txt'
+        ) == 'best-model-with-unicode.txt'
 
     def test_call__slug_precision(self):
         assert FilePattern(filename_pattern='{instance.title:.4slug}{ext}')(


### PR DESCRIPTION
Some tools like the AWS CLI don't do well with unicode file names
even though AWS S3 does not have a problem with them. It is saver
to use ASCII characters only. Which is the default for Django's
builtin slugify method anyways.